### PR TITLE
Integrating Crypto Ancienne

### DIFF
--- a/buildWxApp.nix
+++ b/buildWxApp.nix
@@ -13,7 +13,7 @@
 
   # Whether to link against the wxc C bindings library for wxWidgets.
   withWxc ? false,
-  
+
   # In kilobytes, the size of the two predefined heap blocks.
   # Mac Classic apps need to specify their heap size in advance, so
   # try increasing this if your app crashes on Mac OS 9 but not OS X.

--- a/extras/mac-universal-fix-macro-conflict.patch
+++ b/extras/mac-universal-fix-macro-conflict.patch
@@ -1,6 +1,6 @@
---- /nix/store/cnqklh9lazvy4pxa8nvh2vhgvqnwyj1f-retro68.universal/include/OpenTransport.h        1970-01-01 01:00:01.000000000 +0100
-+++ ./OpenTransport.h        2025-06-11 23:04:07.124320089 +0200
-@@ -17,9 +17,9 @@
+--- a/OpenTransport.h        1970-01-01 01:00:01.000000000 +0100
++++ b/OpenTransport.h        2025-06-11 23:04:07.124320089 +0200
+@@ -17,9 +17,46 @@
  #ifndef __OPENTRANSPORT__
  #define __OPENTRANSPORT__
  
@@ -10,6 +10,43 @@
 +#undef SIGHUP
 +#undef SIGPOLL
 +#undef SIGURG
++#if OTUNIXERRORS
++#undef EWOULDBLOCK
++#undef EALREADY
++#undef ENOTSOCK
++#undef EDESTADDRREQ
++#undef EMSGSIZE
++#undef EPROTOTYPE
++#undef ENOPROTOOPT
++#undef EPROTONOSUPPORT
++#undef EOPNOTSUPP
++#undef EADDRINUSE
++#undef EADDRNOTAVAIL
++#undef ENETDOWN
++#undef ENETUNREACH
++#undef ENETRESET
++#undef ECONNABORTED
++#undef ECONNRESET
++#undef ENOBUFS
++#undef EISCONN
++#undef ENOTCONN
++#undef ESHUTDOWN
++#undef ETOOMANYREFS
++#undef ETIMEDOUT
++#undef ECONNREFUSED
++#undef EHOSTDOWN
++#undef EHOSTUNREACH
++#undef EPROTO
++#undef ETIME
++#undef ENOSR
++#undef EBADMSG
++#undef ECANCEL
++#undef ENOSTR
++#undef ENODATA
++#undef EINPROGRESS
++#undef ESRCH
++#undef ENOMSG
++#endif
  /*
     The following table shows how to map from the old (pre-Universal
     Interfaces) header file name to the equivalent Universal Interfaces

--- a/overlays/all.nix
+++ b/overlays/all.nix
@@ -1,9 +1,11 @@
 self: super: {
   wxWidgets = self.callPackage ../packages/wxWidgets {};
   wxc = self.callPackage ../packages/wxc {};
+  cryanc = self.callPackage ../packages/cryanc {};
 
   buildWxApp = self.callPackage ../buildWxApp.nix {};
 
   wxkitchen-c-demo = self.callPackage ../packages/cdemo {};
   wxkitchen-demo = self.callPackage ../packages/demo {};
+  wxkitchen-c-demo-tls = self.callPackage ../packages/cdemo-tls {};
 }

--- a/overlays/macos.nix
+++ b/overlays/macos.nix
@@ -39,6 +39,8 @@ self: super: {
     '';
   };
 
+  GUSI = self.callPackage ../packages/GUSI {};
+
   # The Universal Interfaces shipped with Retro68's Nix files is too old,
   # so we need to fetch and patch in a new one.
   retro68 =
@@ -96,6 +98,8 @@ self: super: {
             patch $out/include/OpenTransport.h < ${../extras/mac-universal-fix-macro-conflict.patch}
 
             patch -p1 -d $out/RIncludes < ${../extras/mac-universal-fix-rez-syntax.patch}
+
+            ln -s Quickdraw.h $out/include/QuickDraw.h
 
             ln -s . $out/include/Carbon
           '';

--- a/packages/GUSI/cpp-fixes.patch
+++ b/packages/GUSI/cpp-fixes.patch
@@ -1,0 +1,103 @@
+diff -ur GUSI_223/include/GUSIBasics.h GUSI_223_patched/include/GUSIBasics.h
+--- GUSI_223/include/GUSIBasics.h	2025-06-14 17:51:54.508863081 +0200
++++ GUSI_223_patched/include/GUSIBasics.h	2025-06-14 17:57:14.605654659 +0200
+@@ -10,6 +10,10 @@
+ 
+ #include <ConditionalMacros.h>
+ 
++#define ESOCKTNOSUPPORT EINVAL
++#define ELOOK EAGAIN
++#define ESHUTDOWN ENOENT
++
+ // \section{Definition of compiler features}                               
+ //                                                                         
+ // If possible, we use unnamed namespaces to wrap internal code.           
+@@ -20,7 +24,7 @@
+ #endif
+ 
+ #ifdef GUSI_COMPILER_HAS_NAMESPACE
+-#define GUSI_USING_STD_NAMESPACE using namespace std; using namespace std::rel_ops;
++#define GUSI_USING_STD_NAMESPACE using namespace std;
+ #else
+ #define GUSI_USING_STD_NAMESPACE
+ #endif
+@@ -112,8 +116,8 @@
+ //                                                                         
+ // <Definition of hook handling>=                                          
+ #ifdef GUSI_INTERNAL
+-extern GUSISpinFn	gGUSISpinHook;
+-extern GUSIExecFn	gGUSIExecHook;
++extern "C" GUSISpinFn	gGUSISpinHook;
++extern "C" GUSIExecFn	gGUSIExecHook;
+ #endif /* GUSI_INTERNAL */
+ // \section{Definition of error handling}                                  
+ //                                                                         
+@@ -147,8 +151,8 @@
+ // <Definition of error handling>=                                         
+ class GUSIErrorSaver {
+ public:
+-	GUSIErrorSaver()  		{ fSavedErrno = ::errno; ::errno = 0; 	}
+-	~GUSIErrorSaver() 		{ if (!::errno) ::errno = fSavedErrno;  }
++	GUSIErrorSaver()  		{ fSavedErrno = errno; errno = 0; 	}
++	~GUSIErrorSaver() 		{ if (!errno) errno = fSavedErrno;  }
+ private:
+ 	int fSavedErrno;
+ };
+diff -ur GUSI_223/include/GUSIContext.h GUSI_223_patched/include/GUSIContext.h
+--- GUSI_223/include/GUSIContext.h	2025-06-14 17:51:54.511343838 +0200
++++ GUSI_223_patched/include/GUSIContext.h	2025-06-14 18:40:25.346736337 +0200
+@@ -337,18 +337,18 @@
+  // the global error variables.                                             
+  //                                                                         
+  // <Friends of [[GUSIContext]]>=                                           
+- friend pascal void GUSIThreadSwitchIn(ThreadID thread, GUSIContext * context);
+- friend pascal void GUSIThreadSwitchOut(ThreadID thread, GUSIContext * context);
++ pascal void GUSIThreadSwitchIn(ThreadID thread, GUSIContext * context);
++ pascal void GUSIThreadSwitchOut(ThreadID thread, GUSIContext * context);
+  // The terminator wakes up the joining thread if a join is pending.        
+  //                                                                         
+  // <Friends of [[GUSIContext]]>=                                           
+- friend pascal void GUSIThreadTerminator(ThreadID thread, GUSIContext * context);
++pascal void GUSIThreadTerminator(ThreadID thread, GUSIContext * context);
+ 
+ 	GUSIContext(ThreadID id);	
+ 	GUSIContext(
+ 		ThreadEntryProcPtr threadEntry, void *threadParam, 
+ 		Size stackSize, ThreadOptions options, void **threadResult, ThreadID *threadMade);
+-
++public:
+ 	virtual void SwitchIn();
+ 	virtual void SwitchOut();
+ 	virtual void Terminate();
+diff -ur GUSI_223/include/GUSIContextQueue.h GUSI_223_patched/include/GUSIContextQueue.h
+--- GUSI_223/include/GUSIContextQueue.h	2025-06-14 17:51:54.512343824 +0200
++++ GUSI_223_patched/include/GUSIContextQueue.h	2025-06-14 18:27:09.856392052 +0200
+@@ -97,6 +97,7 @@
+  	iterator & operator++();
+  	iterator operator++(int);
+  	bool operator==(const iterator other) const;
++    bool operator!=(const iterator other) const { return !operator==(other); }
+  	GUSIContext * operator*();
+  	GUSIContext * operator->();
+  private:
+@@ -112,7 +113,7 @@
+ 
+  iterator 		begin();
+  iterator 		end();
+-private:
++public:
+ 	// \section{Implementation of context queues}                              
+  //                                                                         
+  // Efficiency of context queues is quite important, so we provide a custom 
+diff -ur GUSI_223/include/GUSISpecific.h GUSI_223_patched/include/GUSISpecific.h
+--- GUSI_223/include/GUSISpecific.h	2025-06-14 17:51:54.533070471 +0200
++++ GUSI_223_patched/include/GUSISpecific.h	2025-06-14 18:07:47.193396729 +0200
+@@ -122,7 +122,7 @@
+ 	
+ 	const GUSISpecific *	Key() const 	{ return &fKey; 						}
+ 	T * get(GUSISpecificTable * table);
+-	T * get()								{ return get(GUSIContext::Current()); 	}
++	T * get();
+ protected:
+ 	GUSISpecific	fKey;
+ };

--- a/packages/GUSI/default.nix
+++ b/packages/GUSI/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = with pkgsBuildBuild; [
     unar
+    dos2unix
+  ];
+
+  patches = [
+    ./cpp-fixes.patch
   ];
 
   unpackPhase = ''
@@ -28,8 +33,17 @@ stdenv.mkDerivation {
        include/machine/ansi.h include/machine/endian.h include/signal.h \
        include/sys/cdefs.h include/sys/errno.h include/sys/signal.h \
        include/sys/stat.h include/sys/time.h include/sys/types.h \
-       include/sys/unistd.h include/unistd.h include/utime.h \
-       include/**/*.rsrc
+       include/sys/unistd.h include/unistd.h include/utime.h
+
+    mac2unix include/*.h
+    mac2unix src/tangled/*.cp
+  '';
+
+  buildPhase = ''
+    for file in src/tangled/*.cp
+    do
+      $CXX -Iinclude -DGUSI_COMPILER_HAS_NAMESPACE -c $file -o $file.o
+    done
   '';
 
   installPhase = ''
@@ -42,6 +56,6 @@ stdenv.mkDerivation {
 
     cp -r include $out/include
 
-    $AR rcs $out/lib/libGUSI.a lib/*.o
+    $AR rcs $out/lib/libGUSI.a src/tangled/*.o
   '';
 }

--- a/packages/GUSI/default.nix
+++ b/packages/GUSI/default.nix
@@ -1,0 +1,47 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  pkgsBuildBuild
+}:
+
+stdenv.mkDerivation {
+  pname = "GUSI";
+  version = "2.2.3";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/gusi/GUSI/2.2.3/GUSI_223.sit.bin";
+    hash = "sha256-DtCVifrzHcUFI+B637lacCsF+OsNSkWyI/miBW7F/94=";
+  };
+
+  nativeBuildInputs = with pkgsBuildBuild; [
+    unar
+  ];
+
+  unpackPhase = ''
+    unar -D $src
+    mv GUSI_223/* .
+  '';
+
+  prePatch = ''
+    rm include/dirent.h include/errno.h include/fcntl.h include/inttypes.h \
+       include/machine/ansi.h include/machine/endian.h include/signal.h \
+       include/sys/cdefs.h include/sys/errno.h include/sys/signal.h \
+       include/sys/stat.h include/sys/time.h include/sys/types.h \
+       include/sys/unistd.h include/unistd.h include/utime.h \
+       include/**/*.rsrc
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+
+    for file in lib/*.MrC.Lib
+    do
+      mv $file ''${file%%.MrC.Lib}.o
+    done
+
+    cp -r include $out/include
+
+    $AR rcs $out/lib/libGUSI.a lib/*.o
+  '';
+}

--- a/packages/GUSI/default.nix
+++ b/packages/GUSI/default.nix
@@ -58,4 +58,18 @@ stdenv.mkDerivation {
 
     $AR rcs $out/lib/libGUSI.a src/tangled/*.o
   '';
+
+  meta = {
+    broken = throw ''Work in progress!
+
+      While GUSI does provide COFF binaries which Retro68 can theoretically
+      understand, in their current state (likely intended for MrC quirks)
+      ld segfaults.
+
+      This package is now focused on building from source. See this page to
+      lift the warning and try to scale the mountain of compile errors:
+
+        https://nixos.org/manual/nixpkgs/stable/#sec-allow-broken
+    '';
+  };
 }

--- a/packages/cdemo-tls/default.nix
+++ b/packages/cdemo-tls/default.nix
@@ -9,7 +9,7 @@
 
 let
   exe = stdenv.hostPlatform.extensions.executable;
-in buildWxApp {
+in buildWxApp rec {
   withWxc = true;
 
   pname = "wxKitchen-C-demo";
@@ -25,13 +25,13 @@ in buildWxApp {
 
   NIX_CFLAGS_COMPILE = "-I${cryanc}/include"
                      + lib.optionalString (stdenv.hostPlatform ? retro68) "-I${GUSI}/include";
-  NIX_CFLAGS_LINK = "-L${cryanc}/lib -lcryanc"
+  NIX_CFLAGS_LINK = "-L${cryanc}/lib -lcryanc "
                   + lib.optionalString (stdenv.hostPlatform ? retro68) "-L${GUSI}/lib -lGUSI";
 
   buildPhase = ''
     mkdir -p $out/bin
     ${lib.optionalString stdenv.hostPlatform.isWindows "$WINDRES -I${wxWidgets}/include -O coff -o demo.res win32/demo.rc"}
     $CC demo.c ${lib.optionalString stdenv.hostPlatform.isWindows "demo.res"} \
-      -o $out/bin/wxKitchenDemoC${exe} $NIX_CFLAGS_LINK
+      -o $out/bin/wxKitchenDemoC${exe} ${NIX_CFLAGS_LINK}
   '';
 }

--- a/packages/cdemo-tls/default.nix
+++ b/packages/cdemo-tls/default.nix
@@ -1,0 +1,37 @@
+{
+  stdenv,
+  lib,
+  buildWxApp,
+  wxWidgets,
+  cryanc,
+  GUSI
+}:
+
+let
+  exe = stdenv.hostPlatform.extensions.executable;
+in buildWxApp {
+  withWxc = true;
+
+  pname = "wxKitchen-C-demo";
+  version = "0.0.0";
+
+  src = ./.;
+
+  buildInputs = [
+    cryanc
+  ] ++ lib.optionals (stdenv.hostPlatform ? retro68) [
+    GUSI
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${cryanc}/include"
+                     + lib.optionalString (stdenv.hostPlatform ? retro68) "-I${GUSI}/include";
+  NIX_CFLAGS_LINK = "-L${cryanc}/lib -lcryanc"
+                  + lib.optionalString (stdenv.hostPlatform ? retro68) "-L${GUSI}/lib -lGUSI";
+
+  buildPhase = ''
+    mkdir -p $out/bin
+    ${lib.optionalString stdenv.hostPlatform.isWindows "$WINDRES -I${wxWidgets}/include -O coff -o demo.res win32/demo.rc"}
+    $CC demo.c ${lib.optionalString stdenv.hostPlatform.isWindows "demo.res"} \
+      -o $out/bin/wxKitchenDemoC${exe} $NIX_CFLAGS_LINK
+  '';
+}

--- a/packages/cdemo-tls/default.nix
+++ b/packages/cdemo-tls/default.nix
@@ -3,8 +3,7 @@
   lib,
   buildWxApp,
   wxWidgets,
-  cryanc,
-  GUSI
+  cryanc
 }:
 
 let
@@ -19,14 +18,10 @@ in buildWxApp rec {
 
   buildInputs = [
     cryanc
-  ] ++ lib.optionals (stdenv.hostPlatform ? retro68) [
-    GUSI
   ];
 
-  NIX_CFLAGS_COMPILE = "-I${cryanc}/include"
-                     + lib.optionalString (stdenv.hostPlatform ? retro68) "-I${GUSI}/include";
-  NIX_CFLAGS_LINK = "-L${cryanc}/lib -lcryanc "
-                  + lib.optionalString (stdenv.hostPlatform ? retro68) "-L${GUSI}/lib -lGUSI";
+  NIX_CFLAGS_COMPILE = "-I${cryanc}/include";
+  NIX_CFLAGS_LINK = "-L${cryanc}/lib -lcryanc";
 
   buildPhase = ''
     mkdir -p $out/bin

--- a/packages/cdemo-tls/demo.c
+++ b/packages/cdemo-tls/demo.c
@@ -1,0 +1,46 @@
+#include <unistd.h>
+#include <stdbool.h>
+#include <wxc.h>
+#include <cryanc.h>
+
+TClass(wxClosure) closure;
+
+void btnClicked(void *evt)
+{
+    tls_init();
+    ELJApp_Exit();
+}
+
+void app_main(void *dat)
+{
+    wxFrame *fr;
+    wxPanel *pan;
+    wxButton *bt;
+    wxClosure *evt;
+
+    fr = wxFrame_Create(NULL, 10, "wxKitchen demo written in C", 40, 40, 320, 240, wxDEFAULT_FRAME_STYLE);
+    pan = wxPanel_Create((wxWindow *) fr, 11, 0, 0, 320, 240, wxTAB_TRAVERSAL);
+    bt = wxButton_Create((wxWindow *) pan, 12, "Nice", 40, 40, 100, 20, wxBU_EXACTFIT);
+    evt = wxClosure_Create(btnClicked, NULL);
+
+    wxBoxSizer *parent = wxBoxSizer_Create(wxVERTICAL);
+    wxBoxSizer *body = wxBoxSizer_Create(wxHORIZONTAL);
+    wxBoxSizer *btns = wxBoxSizer_Create(wxHORIZONTAL);
+
+    wxSizer_AddSizer((wxSizer *) parent, (wxSizer *) body, 1, wxEXPAND, wxALL, NULL);
+    wxSizer_AddSizer((wxSizer *) parent, (wxSizer *) btns, 0, wxALIGN_RIGHT | wxRIGHT | wxBOTTOM, 10, NULL);
+
+    wxSizer_AddWindow((wxSizer *) btns, (wxWindow *) bt, 0, 0, wxALL, NULL);
+
+    wxEvtHandler_Connect((wxEvtHandler *) fr, 12, 12, expEVT_COMMAND_BUTTON_CLICKED(), evt);
+
+    wxWindow_SetSizer((wxWindow *) pan, (wxSizer *) parent);
+
+    wxWindow_Show((wxWindow *) fr);
+    ELJApp_SetTopWindow((wxWindow *) fr);
+}
+
+int main(int argc, char *argv[])
+{
+    ELJApp_InitializeC(wxClosure_Create(app_main, NULL), argc, argv);
+}

--- a/packages/cdemo-tls/demo.c
+++ b/packages/cdemo-tls/demo.c
@@ -8,6 +8,7 @@ TClass(wxClosure) closure;
 void btnClicked(void *evt)
 {
     tls_init();
+
     ELJApp_Exit();
 }
 

--- a/packages/cdemo-tls/win32/demo.rc
+++ b/packages/cdemo-tls/win32/demo.rc
@@ -1,0 +1,1 @@
+#include "wx/msw/wx.rc"

--- a/packages/cryanc/arpa/inet.h
+++ b/packages/cryanc/arpa/inet.h
@@ -1,0 +1,11 @@
+#ifndef __INET_H
+#define __INET_H
+
+#include <machine/endian.h>
+
+#define htonl(x) __htonl(x)
+#define ntohl(x) __ntohl(x)
+#define htons(x) __htons(x)
+#define ntohs(x) __ntohs(x)
+
+#endif //__INET_H

--- a/packages/cryanc/default.nix
+++ b/packages/cryanc/default.nix
@@ -2,19 +2,11 @@
   stdenv,
   lib,
   fetchFromGitHub,
-
-  GUSI ? null
 }:
 
 stdenv.mkDerivation rec {
   pname = "cryanc";
   version = "2.2";
-
-  NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.hostPlatform ? retro68) "-I${GUSI}/include";
-
-  propagatedBuildInputs = lib.optionals (stdenv.hostPlatform ? retro68) [
-    GUSI
-  ];
 
   src = fetchFromGitHub {
     owner = "classilla";
@@ -23,13 +15,15 @@ stdenv.mkDerivation rec {
     hash = "sha256-eFMQYQGYGkVQAVz3V41Xm238TNqyQqY4gDYEaFLJuD8=";
   };
 
+  NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.hostPlatform ? retro68) "-Dusleep=sqrt";
+
   buildPhase = ''
-    $CC -c cryanc.c -o cryanc.o
+    $CC -I${./.} -c cryanc.c -o cryanc.o
   '';
 
   installPhase = ''
     mkdir -p $out/lib $out/include
-    cp cryanc.h $out/include/
+    cp -r cryanc.h ${./.}/arpa $out/include/
     $AR rcs $out/lib/libcryanc.a cryanc.o
   '';
 }

--- a/packages/cryanc/default.nix
+++ b/packages/cryanc/default.nix
@@ -1,0 +1,35 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+
+  GUSI ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cryanc";
+  version = "2.2";
+
+  NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.hostPlatform ? retro68) "-I${GUSI}/include";
+
+  propagatedBuildInputs = lib.optionals (stdenv.hostPlatform ? retro68) [
+    GUSI
+  ];
+
+  src = fetchFromGitHub {
+    owner = "classilla";
+    repo = pname;
+    rev = version;
+    hash = "sha256-eFMQYQGYGkVQAVz3V41Xm238TNqyQqY4gDYEaFLJuD8=";
+  };
+
+  buildPhase = ''
+    $CC -c cryanc.c -o cryanc.o
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib $out/include
+    cp cryanc.h $out/include/
+    $AR rcs $out/lib/libcryanc.a cryanc.o
+  '';
+}

--- a/packages/wxWidgets/default.nix
+++ b/packages/wxWidgets/default.nix
@@ -58,6 +58,7 @@ in stdenv.mkDerivation rec {
       ./patches/0006-mac-fix-return-types.patch
       ./patches/0007-mac-define-verify-macros.patch
       ./patches/0008-mac-fix-corefoundation-includes.patch
+      ./patches/0009-mac-fix-gsocket-includes.patch
     ];
 
   # This is how you know this software is very obsolete
@@ -87,8 +88,9 @@ in stdenv.mkDerivation rec {
   ${retro68.tools}/bin/Rez -I ${retro68.universal}/RIncludes ${retro68.libretro}/RIncludes/RetroCarbonAPPL.r -DCFRAG_NAME="\"$(basename $1)\"" --data $1.pef -o $1.bin -t $TYPE -c ro68
   '');
 
-  postPatch = ''
+  postPatch = lib.optionalString isRetro68 ''
     cat ${./mac-missing-glue.c} >> src/mac/carbon/utils.cpp
+    sed -ie 's/wxUSE_SOCKETS=no/wxUSE_SOCKETS=yes/g' configure
   '';
 
   configureFlags =
@@ -115,6 +117,8 @@ in stdenv.mkDerivation rec {
     pushd $out/include
     ln -s wx-*/* .
     popd
+
+    cp include/MacHeaders.c $out/lib/wx/include/*/
 
     mkdir -p $out/nix-support
     $out/bin/wx-config --cflags > $out/nix-support/cc-cflags

--- a/packages/wxWidgets/patches/0001-mac-disable-win32-defines.patch
+++ b/packages/wxWidgets/patches/0001-mac-disable-win32-defines.patch
@@ -7,7 +7,7 @@ index 71abcfc..8430a44 100644
  #    endif
  
 -#else   /* Windows */
-+#elif defined(__WIN32__)   /* Windows */
++#elif defined(_WIN32)   /* Windows */
  #    ifndef __WINDOWS__
  #        define __WINDOWS__
  #    endif  /* Windows */

--- a/packages/wxWidgets/patches/0009-mac-fix-gsocket-includes.patch
+++ b/packages/wxWidgets/patches/0009-mac-fix-gsocket-includes.patch
@@ -1,0 +1,9 @@
+diff --git a/include/MacHeaders.c b/include/MacHeaders.c
+new file mode 100644
+index 0000000..05c1cc6
+--- /dev/null
++++ b/include/MacHeaders.c
+@@ -0,0 +1,3 @@
++#include <wx/mac/carbon/macnotfy.h>
++
++#include <Timer.h>


### PR DESCRIPTION
The goal is to get TLS networking to build on Windows 9x and Mac OS 9, to enable interaction with modern networking apps.

On Mac OS 9, sockets may require integrating GUSI, the Grand Unified Socket Interface, which currently does not play well with the Retro68 toolchain.